### PR TITLE
Fix false caveat

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,5 +15,3 @@ echo "Hello, world" | ./encode >file
 
 You can either use ~decode-buf~ or ~decode-checkchar~. Both of them seem
 equally fast. ~decode~ and ~decode-buf~ are the same.
-* Caveats
-The input to ~encode~ and ~decode~ /must/ end with a newline.

--- a/decode
+++ b/decode
@@ -81,7 +81,7 @@ ch() {
 }
 
 sum=0
-while read -r l; do
+while read -r l || [ -n "$l" ]; do
 	while [ -n "$l" ]; do
 		buf
 	done

--- a/decode-buf
+++ b/decode-buf
@@ -12,7 +12,7 @@ bss='👉'
 bse='👈'
 
 sum=0
-while read -r l; do
+while read -r l || [ -n "$l" ]; do
 	while [ -n "$l" ]; do
 		char="${l%"${l#?}"}"
 		buf="$buf$char"

--- a/decode-checkchar
+++ b/decode-checkchar
@@ -11,7 +11,7 @@ bss='👉'
 bse='👈'
 sum=0
 
-while read -r l; do
+while read -r l || [ -n "$l" ]; do
 	while [ -n "$l" ]; do
 		for i in "$bse" "$bss" "$i0" "$i200" "$i50" "$i10" \
 						"$i5" "$i1"; do

--- a/encode
+++ b/encode
@@ -8,7 +8,7 @@ i1=','
 i0='❤️'
 bs='👉👈'
 
-while read -r l; do
+while read -r l || [ -n "$l" ]; do
 	l="$l
 "
 	while [ -n "$l" ]; do


### PR DESCRIPTION
> The input to encode and decode must end with a newline.

This is actually false; you just didn't write the `while read` loop correctly...

```sh
while -r $var || [ -n "$var" ]; do
#
done
```
above is the correct way; I took the liberty to both fix said issue and test that it works fine that way

---

The below test command shows that it both continues to work fine, and now works when STDIN does _NOT_ end with a newline
```sh
printf '%s' "$(printf "test" | ./encode)" | ./decode
```